### PR TITLE
meson override 'cargs' dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,3 +13,7 @@ cargs = library('cargs', 'src/cargs.c',
 install_headers('include/cargs.h')
 
 cargs_dep = declare_dependency(include_directories: 'include', link_with: cargs)
+
+if meson.version().version_compare('>= 0.54.0')
+  meson.override_dependency('cargs', cargs_dep)
+endif


### PR DESCRIPTION
Starting from 0.54.0, meson introduced the ability to override
dependencies. This eases the usage of the library as a subproject.

More info can be found at:
https://mesonbuild.com/Release-notes-for-0-54-0.html#override-dependency

Signed-off-by: Robear Selwans <robear.selwans@outlook.com>