### PR TITLE
feat: add API to retrieve invalid option

### DIFF
--- a/include/cargs.h
+++ b/include/cargs.h
@@ -156,6 +156,8 @@ CAG_PUBLIC const char *cag_option_get_value(const cag_option_context *context);
  */
 CAG_PUBLIC int cag_option_get_index(const cag_option_context *context);
 
+CAG_PUBLIC const char *cag_option_get_invalid(const cag_option_context *context);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/include/cargs.h
+++ b/include/cargs.h
@@ -63,6 +63,7 @@ typedef struct cag_option_context
   char **argv;
   int index;
   int inner_index;
+  int failed_index;
   bool forced_end;
   char identifier;
   char *value;

--- a/include/cargs.h
+++ b/include/cargs.h
@@ -156,6 +156,16 @@ CAG_PUBLIC const char *cag_option_get_value(const cag_option_context *context);
  */
 CAG_PUBLIC int cag_option_get_index(const cag_option_context *context);
 
+/**
+ * @brief Gets an invalid option if found
+ *
+ * This function gets an invalid option if an option doesn't match one of options
+ * from `cag_option` list. This is useful if you want more detailed error
+ * about an invalid option found.
+ *
+ * @param context The context from which the option was fetched.
+ * @return Returns a string where it contains the invalid option.
+ */
 CAG_PUBLIC const char *cag_option_get_invalid(const cag_option_context *context);
 
 #ifdef __cplusplus

--- a/src/cargs.c
+++ b/src/cargs.c
@@ -233,6 +233,7 @@ static void cag_option_parse_access_name(cag_option_context *context, char **c)
   // it will remain '?' within the context.
   option = cag_option_find_by_name(context, n, (size_t)(*c - n));
   if (option == NULL) {
+    context->failed_index = context->index;
     // Since this option is invalid, we will move on to the next index. There is
     // nothing we can do about this.
     ++context->index;
@@ -266,6 +267,7 @@ static void cag_option_parse_access_letter(cag_option_context *context,
   // specifically, it will remain '?' within the context.
   option = cag_option_find_by_letter(context, n[context->inner_index]);
   if (option == NULL) {
+    context->failed_index = context->index;
     ++context->index;
     context->inner_index = 0;
     return;
@@ -434,4 +436,9 @@ int cag_option_get_index(const cag_option_context *context)
 {
   // Either we point to a value item,
   return context->index;
+}
+
+const char *cag_option_get_invalid(const cag_option_context *context)
+{
+  return context->argv[context->failed_index];
 }

--- a/src/cargs.c
+++ b/src/cargs.c
@@ -440,5 +440,5 @@ int cag_option_get_index(const cag_option_context *context)
 
 const char *cag_option_get_invalid(const cag_option_context *context)
 {
-  return context->argv[context->failed_index];
+  return context->argv[context->failed_index-1];
 }


### PR DESCRIPTION
added:
- `cag_option_get_invalid` function
- `cag_option_context.failed_index` field

closes #8
