### PR TITLE
Fix include_directories kwarg of type string meson warning

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,7 @@ cargs = library('cargs', 'src/cargs.c',
 
 install_headers('include/cargs.h')
 
-cargs_dep = declare_dependency(include_directories: 'include', link_with: cargs)
+cargs_dep = declare_dependency(include_directories: cargs_inc, link_with: cargs)
 
 if meson.version().version_compare('>= 0.54.0')
   meson.override_dependency('cargs', cargs_dep)


### PR DESCRIPTION
The PR fixes the meson warning when including `cargs` as a meson subproject:

![image](https://github.com/user-attachments/assets/dd4b6d5e-ce25-4343-abf0-0517cefe31e2)
